### PR TITLE
Fixed JSON typo for Timer events

### DIFF
--- a/lib/decision-task.js
+++ b/lib/decision-task.js
@@ -58,7 +58,7 @@ DecisionTask.prototype = {
                 throw "Cannot wait for " + activityId + " , activity has faild";
             }
 
-            // TODO: 
+            // TODO:
             /*if ( this.is_activity_canceled(activityId) ) {
                 throw new Error("Cannot wait for " +activityId+ " , activity was canceled");
             }*/
@@ -207,7 +207,7 @@ DecisionTask.prototype = {
     start_timer: function (timerId, startToFireTimeout, control, cb) {
         this.respondCompleted([{
             "decisionType": "StartTimer",
-            "StartTimerDecisionAttributes": {
+            "startTimerDecisionAttributes": {
                 "timerId": timerId,
                 "startToFireTimeout": startToFireTimeout,
                 "control": control
@@ -218,7 +218,7 @@ DecisionTask.prototype = {
     cancel_timer: function (timerId, cb) {
         this.respondCompleted([{
             "decisionType": "CancelTimer",
-            "CancelTimerDecisionAttributes": {
+            "cancelTimerDecisionAttributes": {
                 "timerId": timerId
             }
         }], cb);


### PR DESCRIPTION
I fixed a syntax error in the JSON related to Timer events. You can see from the Amazon SWF developer forum that others have hit this same problem: https://forums.aws.amazon.com/message.jspa?messageID=379353.

Apparently the docs are incorrect, and show the attribute names starting with capitalized letters when they must be lowercase.

If you use the existing implementation you'll get the following error:
RespondDecisionTaskCompleted error :  { __type: 'com.amazon.coral.validate#ValidationException',
  message: 'StartTimerDecisionAttributes must be specified for decision of type StartTimer' } null
