### PR TITLE
Add alternative callback that would call with the execution

### DIFF
--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -28,6 +28,20 @@ Workflow.prototype = {
     },
 
     /**
+     * Just like `start()`, but callback passes the workflow execution with the
+     * run ID with no return value
+     * @param {Object} config
+     * @param {Function} [cb] - called once the workflow execution started
+     * @returns {WorkflowExecution} workflowExecution - The new instance of the workflow execution
+     */
+    startCb: function (config, cb) {
+      var w = this.start(config, function (err, runId) {
+        w.runId = runId;
+        cb.call(this, err, w);
+      });
+    },
+
+    /**
      * register the workflow
      * @param {Function} [cb]
      */


### PR DESCRIPTION
A use case would be wrapping the callback in a promise.
