### PR TITLE
Use a newer version of aws-sdk (and allow automatic updates in the future)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "http://github.com/neyric/aws-swf.git"
   },
   "dependencies": {
-    "aws-sdk": "2.0.0-rc9",
+    "aws-sdk": "~2.0.0-rc",
     "lodash": "~2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I'd like to configure the AWS SDK using my ~/.aws/credentials file, but support for that was only added in aws-sdk > 2.0.0-rc.15.
