### PR TITLE
Remove 'client' references because the property has been removed from AWS SDK

### DIFF
--- a/examples/simple-register.js
+++ b/examples/simple-register.js
@@ -11,7 +11,7 @@ var awsswf = require('../index'),
 /**
  * Register the domain "test-domain"
  */
-swf.client.registerDomain({
+swf.registerDomain({
     name: "test-domain",
     description: "this is a just a test domain",
     workflowExecutionRetentionPeriodInDays: "1"
@@ -27,7 +27,7 @@ swf.client.registerDomain({
     /**
      * Register the WorkflowType "simple-workflow"
      */
-    swf.client.registerWorkflowType({
+    swf.registerWorkflowType({
         domain: "test-domain",
         name: "simple-workflow",
         version: "1.0"
@@ -42,7 +42,7 @@ swf.client.registerDomain({
         /**
          * Register the ActivityType "simple-activity"
          */
-        swf.client.registerActivityType({
+        swf.registerActivityType({
             domain: "test-domain",
             name: "simple-activity",
             version: "1.0"

--- a/lib/activity-task.js
+++ b/lib/activity-task.js
@@ -35,7 +35,7 @@ ActivityTask.prototype = {
      */
     respondCompleted: function (result, cb) {
 
-        this.swfClient.client.respondActivityTaskCompleted({
+        this.swfClient.respondActivityTaskCompleted({
             result: stringify(result),
             taskToken: this.config.taskToken
         }, function (err) {
@@ -71,7 +71,7 @@ ActivityTask.prototype = {
             o.details = stringify(details);
         }
 
-        this.swfClient.client.respondActivityTaskFailed(o, function (err) {
+        this.swfClient.respondActivityTaskFailed(o, function (err) {
 
             if (err) {
                 console.log("Error while sending RespondActivityTaskFailed : ", err);
@@ -92,7 +92,7 @@ ActivityTask.prototype = {
      */
     recordHeartbeat: function (heartbeat, cb) {
 
-        this.swfClient.client.recordActivityTaskHeartbeat({
+        this.swfClient.recordActivityTaskHeartbeat({
             taskToken: this.config.taskToken,
             details: stringify(heartbeat)
         }, function (err) {

--- a/lib/decider.js
+++ b/lib/decider.js
@@ -43,7 +43,7 @@ Decider.prototype._onNewTask = function(originalResult,result,_this, events) {
     if(result.nextPageToken) {
         var pollConfig = _.clone(this.config);
         pollConfig.nextPageToken = result.nextPageToken;
-        this.swfClient.client[this.pollMethod](pollConfig, function (err, nextPageResult) {
+        this.swfClient[this.pollMethod](pollConfig, function (err, nextPageResult) {
             if (err) {
                 _this.emit('error', err);
                 return;

--- a/lib/decision-response.js
+++ b/lib/decision-response.js
@@ -45,7 +45,7 @@ DecisionResponse.prototype = {
       this.responseSent = true;
 
 
-      this.swfClient.client.respondDecisionTaskCompleted({
+      this.swfClient.respondDecisionTaskCompleted({
          "taskToken": this.taskToken,
          "decisions": decisions
       }, function (err, result) {

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -91,7 +91,7 @@ Poller.prototype.poll = function () {
    // Poll request on AWS
    // http://docs.aws.amazon.com/amazonswf/latest/apireference/API_PollForDecisionTask.html
    var _this = this;
-   this.request = this.swfClient.client[this.pollMethod](o, function (err, result) {
+   this.request = this.swfClient[this.pollMethod](o, function (err, result) {
 
       if (err) {
         /**

--- a/lib/workflow-execution.js
+++ b/lib/workflow-execution.js
@@ -39,7 +39,7 @@ WorkflowExecution.prototype = {
 
         this.workflowId = o.workflowId;
 
-        this.swfClient.client.startWorkflowExecution(o, function (err, result) {
+        this.swfClient.startWorkflowExecution(o, function (err, result) {
             cb(err, result ? result.runId : null);
         });
     },
@@ -65,7 +65,7 @@ WorkflowExecution.prototype = {
      */
     signal: function (config, cb) {
         var o = this._prepare_options(config);
-        this.swfClient.client.signalWorkflowExecution(o, cb);
+        this.swfClient.signalWorkflowExecution(o, cb);
     },
 
     /**
@@ -75,7 +75,7 @@ WorkflowExecution.prototype = {
      */
     terminate: function (config, cb) {
         var o = this._prepare_options(config);
-        this.swfClient.client.terminateWorkflowExecution(o, cb);
+        this.swfClient.terminateWorkflowExecution(o, cb);
     },
 
     /**
@@ -95,7 +95,7 @@ WorkflowExecution.prototype = {
             }
         }
 
-        this.swfClient.client.getWorkflowExecutionHistory(o, cb);
+        this.swfClient.getWorkflowExecutionHistory(o, cb);
     }
 
 };

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -47,7 +47,7 @@ Workflow.prototype = {
      * @param {Function} [cb]
      */
     register: function (cb) {
-        this.swfClient.client.registerWorkflowType({
+        this.swfClient.registerWorkflowType({
             "domain": this.config.domain,
             "name": this.config.workflowType.name,
             "version": this.config.workflowType.version

--- a/test/test_ActivityPoller.js
+++ b/test/test_ActivityPoller.js
@@ -7,17 +7,15 @@ var ActivityPoller = swf.ActivityPoller;
 
 var pollForActivityTaskCallCount = 0;
 var swfClientMock = {
-  client: {
     pollForActivityTask: function(p, cb) {
-      pollForActivityTaskCallCount += 1;
-
-      setTimeout(function() {
-        cb(null, {
-          taskToken: (pollForActivityTaskCallCount == 2) ? '12345' : undefined
-        });
-      }, 10);
+        pollForActivityTaskCallCount += 1;
+        
+        setTimeout(function() {
+            cb(null, {
+                taskToken: (pollForActivityTaskCallCount == 2) ? '12345' : undefined
+            });
+        }, 10);
     }
-  }
 };
 
 describe('ActivityPoller', function(){

--- a/test/test_ActivityTask.js
+++ b/test/test_ActivityTask.js
@@ -6,22 +6,18 @@ var ActivityTask = swf.ActivityTask;
 
 var mockSwfClient = {
 
-  client: {
-
     respondActivityTaskCompleted: function(p, cb) {
-      cb();
+        cb();
     },
-
+    
     respondActivityTaskFailed: function(p, cb) {
-      cb();
+        cb();
     },
-
+    
     recordActivityTaskHeartbeat: function(p, cb) {
-      cb();
+        cb();
     }
-
-  }
-
+    
 };
 
 describe('ActivityTask', function(){

--- a/test/test_Decider.js
+++ b/test/test_Decider.js
@@ -7,37 +7,35 @@ var Decider = swf.Decider;
 
 var pollForDecisionTaskCallCount = 0;
 var swfClientMock = {
-  client: {
-    pollForDecisionTask: function(p, cb) {
-      pollForDecisionTaskCallCount += 1;
+  pollForDecisionTask: function(p, cb) {
+    pollForDecisionTaskCallCount += 1;
 
-      setTimeout(function() {
-        cb(null, {
-          taskToken: '12345',
-          events: /*(pollForDecisionTaskCallCount == 1) ?*/ [
-            {
-              "eventId": 1,
-              "eventTimestamp": 1326592619.474,
-              "eventType": "WorkflowExecutionStarted",
-              "workflowExecutionStartedEventAttributes": {
-                 "childPolicy": "TERMINATE",
-                 "executionStartToCloseTimeout": "3600",
-                 "input": "arbitrary-string-that-is-meaningful-to-the-workflow",
-                 "parentInitiatedEventId": 0,
-                 "tagList": ["music purchase", "digital", "ricoh-the-dog"],
-                 "taskList": {"name": "specialTaskList"},
-                 "taskStartToCloseTimeout": "600",
-                 "workflowType": {
-                    "name": "customerOrderWorkflow",
-                    "version": "1.0"
-                 }
-              }
-           }
-          ] /*: []*//*,
-          nextPageToken: (pollForDecisionTaskCallCount == 1) ? 'THENEXTPAGET' : undefined*/
-        });
-      }, 10);
-    }
+    setTimeout(function() {
+      cb(null, {
+        taskToken: '12345',
+        events: /*(pollForDecisionTaskCallCount == 1) ?*/ [
+          {
+            "eventId": 1,
+            "eventTimestamp": 1326592619.474,
+            "eventType": "WorkflowExecutionStarted",
+            "workflowExecutionStartedEventAttributes": {
+               "childPolicy": "TERMINATE",
+               "executionStartToCloseTimeout": "3600",
+               "input": "arbitrary-string-that-is-meaningful-to-the-workflow",
+               "parentInitiatedEventId": 0,
+               "tagList": ["music purchase", "digital", "ricoh-the-dog"],
+               "taskList": {"name": "specialTaskList"},
+               "taskStartToCloseTimeout": "600",
+               "workflowType": {
+                  "name": "customerOrderWorkflow",
+                  "version": "1.0"
+               }
+            }
+         }
+        ] /*: []*//*,
+        nextPageToken: (pollForDecisionTaskCallCount == 1) ? 'THENEXTPAGET' : undefined*/
+      });
+    }, 10);
   }
 };
 

--- a/test/test_DecisionResponse.js
+++ b/test/test_DecisionResponse.js
@@ -6,10 +6,8 @@ var DecisionResponse = swf.DecisionResponse;
 
 
 var swfClientMock = {
-  client: {
-    respondDecisionTaskCompleted: function(p, cb) {
-      cb();
-    }
+  respondDecisionTaskCompleted: function(p, cb) {
+    cb();
   }
 };
 

--- a/test/test_Workflow.js
+++ b/test/test_Workflow.js
@@ -5,21 +5,16 @@ var swf = require('../index');
 var Workflow = swf.Workflow;
 
 var mockSwfClient = {
-
-  client: {
-
-    startWorkflowExecution: function(p, cb) {
-      process.nextTick(function () {
-          cb(null, {
-              runId: '12345678'
-          });
+  startWorkflowExecution: function(p, cb) {
+    process.nextTick(function () {
+        cb(null, {
+            runId: '12345678'
+        });
       });
     },
 
-    registerWorkflowType: function(p, cb) {
-      cb();
-    }
-
+  registerWorkflowType: function(p, cb) {
+    cb();
   }
 
 };
@@ -60,8 +55,8 @@ describe('Workflow', function(){
 
     it('should handle immediate errors gracefully', function(done) {
       var erroringSwfClient = Object.create(mockSwfClient);
-      erroringSwfClient.client = Object.create(mockSwfClient.client);
-      erroringSwfClient.client.startWorkflowExecution = function (p, cb) {
+      erroringSwfClient = Object.create(mockSwfClient);
+      erroringSwfClient.startWorkflowExecution = function (p, cb) {
           // Intentionally do not wait for the next tick to report the error
           cb(new Error('Unexpected failure'));
       };

--- a/test/test_WorkflowExecution.js
+++ b/test/test_WorkflowExecution.js
@@ -6,28 +6,23 @@ var WorkflowExecution = swf.WorkflowExecution;
 
 var mockSwfClient = {
 
-  client: {
-
-    startWorkflowExecution: function(p, cb) {
-      cb(null, {
-        runId: '12345678'
-      });
-    },
-
-    signalWorkflowExecution: function(p, cb) {
-      cb();
-    },
-
-    getWorkflowExecutionHistory: function(p, cb) {
-      cb();
-    },
-
-    terminateWorkflowExecution: function(p, cb) {
-      cb();
-    }
-
+  startWorkflowExecution: function(p, cb) {
+    cb(null, {
+      runId: '12345678'
+    });
+  },
+    
+  signalWorkflowExecution: function(p, cb) {
+    cb();
+  },
+    
+  getWorkflowExecutionHistory: function(p, cb) {
+    cb();
+  },
+    
+  terminateWorkflowExecution: function(p, cb) {
+    cb();
   }
-
 };
 
 describe('WorkflowExecution', function(){


### PR DESCRIPTION
From the official release notes here:  http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/file.UPGRADING.html#4__Dropped__Client_Property and made official in commit aws/aws-sdk-js@a6ee7496a330183a75e81621d817c8167c7c1404 the .client property has been removed.

This change moves the codebase to the non-deprecated API
