### PR TITLE
Updating to latest aws-sdk / lodash libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "url": "http://github.com/neyric/aws-swf.git"
   },
   "dependencies": {
-    "aws-sdk": "~2.0.7",
-    "lodash": "~2.4.1"
+    "aws-sdk": "~2.1.23",
+    "lodash": "~3.6.0"
   },
   "devDependencies": {
     "coveralls": "~2.8.0",


### PR DESCRIPTION
Would like to get this lib on the latest sdk from AWS... updated lodash while I was at it.

If you accept this, would it be possible to push out 4.2.0 with these changes?