### PR TITLE
Fixed tested broken in #37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
+  - "6.2"
+  - "5"
+  - "4"
   - "0.11"
   - "0.10"
-  - "0.8"
+  - "iojs"
 after_script: NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/lib/activity-task.js
+++ b/lib/activity-task.js
@@ -38,7 +38,9 @@ ActivityTask.prototype = {
             this.swfClient.respondActivityTaskCanceled(
                 params,
                 function (err, data){
-                    self.onDone()
+                    if (self.onDone) {
+                        self.onDone();
+                    }
                     if (cb){
                         cb(err)
                     }
@@ -57,7 +59,9 @@ ActivityTask.prototype = {
             result: stringify(result),
             taskToken: this.config.taskToken
         }, function (err) {
-            self.onDone()
+            if (self.onDone) {
+                self.onDone();
+            }
             if (cb) {
                 cb(err);
             }
@@ -86,7 +90,9 @@ ActivityTask.prototype = {
         }
 
         this.swfClient.respondActivityTaskFailed(o, function (err) {
-            self.onDone()
+            if (self.onDone) {
+                self.onDone();
+            }
             if (cb) {
                 cb(err);
             }

--- a/lib/decision-response.js
+++ b/lib/decision-response.js
@@ -49,7 +49,9 @@ DecisionResponse.prototype = {
          "taskToken": this.taskToken,
          "decisions": decisions
       }, function (err, result) {
-         self.onDone();
+         if (self.onDone) {
+            self.onDone();
+         }
          if (cb) {
             cb(err, result);
          }

--- a/test/test_Decider.js
+++ b/test/test_Decider.js
@@ -12,8 +12,8 @@ var swfClientMock = {
 
     setTimeout(function() {
       cb(null, {
-        taskToken: '12345',
-        events: /*(pollForDecisionTaskCallCount == 1) ?*/ [
+        taskToken: (pollForDecisionTaskCallCount == 1) ? '12345' : '',
+        events: (pollForDecisionTaskCallCount == 1) ? [
           {
             "eventId": 1,
             "eventTimestamp": 1326592619.474,
@@ -32,8 +32,8 @@ var swfClientMock = {
                }
             }
          }
-        ] /*: []*//*,
-        nextPageToken: (pollForDecisionTaskCallCount == 1) ? 'THENEXTPAGET' : undefined*/
+       ] : [],
+        nextPageToken: (pollForDecisionTaskCallCount == 1) ? 'THENEXTPAGET' : undefined
       });
     }, 10);
   }


### PR DESCRIPTION
This fixes tests which were broken in #37. Two types of fixes:

* `onDone` is not always defined, so we add a guard before calling it
* the `swfClientMock` was returning the same event twice. I uncommented some code and also made `taskToken` an empty string on the second call

For the second fix, I think this is the correct behaviour. See http://docs.aws.amazon.com/amazonswf/latest/apireference/API_PollForDecisionTask.html : "An empty result, in this context, means that a DecisionTask is returned, but that the value of taskToken is an empty string."

Also, verify that builds are passing here: https://circleci.com/gh/ktonon/aws-swf/5