### PR TITLE
Add behavior for polling error recovery, fix tests

### DIFF
--- a/lib/activity-poller.js
+++ b/lib/activity-poller.js
@@ -5,12 +5,13 @@ var util = require('util'),
 /**
  * Polls Amazon SWF for new Activity Tasks
  * @constructor
- * @param {Object} config Ex: { domain: "my-domain", taskList: {name: "my-taskList"} }
+ * @param {Object} config Ex: { domain: "my-domain", taskList: {name: "my-taskList"}, errorRetryDelay: 5000, errorRetryLimit: 10 }
  * @param {Object} [swfClient]
  * @augments Poller
  * @fires ActivityPoller#activityTask
  * @fires Poller#poll
  * @fires Poller#error
+ * @fires Poller#fatal
  */
 var ActivityPoller = exports.ActivityPoller = function (config, swfClient) {
 

--- a/lib/decider.js
+++ b/lib/decider.js
@@ -6,12 +6,13 @@ var util = require('util'),
 /**
  * Decider polls Amazon SWF for new Decision Tasks
  * @constructor
- * @param {Object} config Ex: { domain: "my-domain", taskList: {name: "my-taskList"} }
+ * @param {Object} config Ex: { domain: "my-domain", taskList: {name: "my-taskList"}, errorRetryDelay: 5000, errorRetryLimit: 10 }
  * @param {Object} [swfClient]
  * @augments Poller
  * @fires Decider#decisionTask
  * @fires Poller#poll
  * @fires Poller#error
+ * @fires Poller#fatal
  */
 var Decider = exports.Decider = function (config, swfClient) {
 

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -11,6 +11,7 @@ var events = require('events'),
  * @abstract
  * @fires Poller#poll
  * @fires Poller#error
+ * @fires Poller#fatal
  */
 var Poller = exports.Poller = function(config, swfClient) {
 
@@ -27,6 +28,9 @@ var Poller = exports.Poller = function(config, swfClient) {
    this.logger = config.logger || console;
    delete config.logger
    this.taskLimitation = Number.MAX_SAFE_INTEGER;
+   this.errorRetryDelay = config.errorRetryDelay || 0;
+   this.errorRetryLimit = config.errorRetryLimit || 10;
+   this.unsuccessfulPolls = 0;
    this.taskQueue = async.queue(function(queueFunc, callback){
     queueFunc(callback);
    }, this.taskLimitation);
@@ -122,7 +126,6 @@ Poller.prototype.poll = function () {
    // http://docs.aws.amazon.com/amazonswf/latest/apireference/API_PollForDecisionTask.html
    var _this = this;
    this.request = this.swfClient[this.pollMethod](o, function (err, result) {
-
       if (err) {
         /**
          * Emitted if an error occured during polling
@@ -130,9 +133,29 @@ Poller.prototype.poll = function () {
          * @event Poller#error
          * @property {Object} err - The error
          */
-         _this.emit('error', err);
+
+         if (_this.errorRetryDelay > 0 && _this.unsuccessfulPolls < _this.errorRetryLimit) {
+          /**
+           * Emitted if an error occured during polling
+           *
+           * @event Poller#error
+           * @property {Object} err - The error
+           */
+           _this.emit('error', err);
+           _this.unsuccessfulPolls += 1;
+
+           setTimeout(function() {
+             _this.poll();
+           }, _this.errorRetryDelay);
+
+           return;
+         }
+
+         _this.emit('fatal', err);
          return;
       }
+
+      _this.unsuccessfulPolls = 0;
 
       // If no new task, re-poll
       if (!result.taskToken) {

--- a/test/test_ActivityTask.js
+++ b/test/test_ActivityTask.js
@@ -17,7 +17,13 @@ var mockSwfClient = {
     recordActivityTaskHeartbeat: function(p, cb) {
         cb();
     }
-    
+
+}
+
+var getActivityTask = function(config, client) {
+  var t = new ActivityTask(config, client);
+  t.onDone = function() {};
+  return t;
 };
 
 describe('ActivityTask', function(){
@@ -30,7 +36,7 @@ describe('ActivityTask', function(){
 
   describe('#respondCompleted()', function() {
 
-    var t = new ActivityTask({}, mockSwfClient);
+    var t = getActivityTask({}, mockSwfClient);
 
     it('with string data', function(done) {
       t.respondCompleted("some result data...", done);
@@ -49,7 +55,7 @@ describe('ActivityTask', function(){
 
   describe('#respondFailed()', function() {
 
-    var t = new ActivityTask({}, mockSwfClient);
+    var t = getActivityTask({}, mockSwfClient);
 
     it('with string data', function(done) {
       t.respondFailed("some reason", "details here", done);
@@ -63,7 +69,7 @@ describe('ActivityTask', function(){
 
   describe('#recordHeartbeat()', function() {
 
-    var t = new ActivityTask({}, mockSwfClient);
+    var t = getActivityTask({}, mockSwfClient);
 
     it('with string details', function(done) {
       t.recordHeartbeat("some reason", done);

--- a/test/test_Decider.js
+++ b/test/test_Decider.js
@@ -57,7 +57,7 @@ describe('Decider', function(){
     });
 
     it('should start, emit DecisionTask, and stop', function(done) {
-
+      var doneCalled = false;
       var decider = new Decider({
         domain: 'test-domain',
         taskList: {
@@ -68,7 +68,10 @@ describe('Decider', function(){
 
       decider.on('decisionTask', function(decisionTask) {
         decider.stop();
-        done();
+        if (!doneCalled) {
+          doneCalled = true;
+          done();
+        }
       });
 
       decider.start();

--- a/test/test_DecisionResponse.js
+++ b/test/test_DecisionResponse.js
@@ -26,6 +26,7 @@ describe('DecisionResponse', function(){
 
     it('#send()', function(done) {
       var dr = new DecisionResponse(swfClientMock, '12345', 'my-tasklist');
+      dr.onDone = function() {};
       dr.stop({
         result: "some results"
       });
@@ -51,6 +52,7 @@ describe('DecisionResponse', function(){
 
     it('#fail()', function(done) {
       var dr = new DecisionResponse(swfClientMock, '12345', 'my-tasklist');
+      dr.onDone = function() {};
       dr.fail("", "", done);
     });
 


### PR DESCRIPTION
Added new polling options for retrying after errors rather than dying forever.  Added a new event for when retrying stops because of too many errors.  Fixed tests that were failing locally and added a new one for the error behavior.
