### PR TITLE
Easier integration with supervisor

### DIFF
--- a/examples/simple-activity-worker.js
+++ b/examples/simple-activity-worker.js
@@ -40,10 +40,8 @@ activityPoller.start();
  * It is not recommanded to stop the poller in the middle of a long-polling request,
  * because SWF might schedule an ActivityTask to this poller anyway, which will obviously timeout.
  *
- * The .stop() method will wait for the end of the current polling request, 
+ * The .stopHandler() method will wait for the end of the current polling request, 
  * eventually wait for a last activity execution, then stop properly :
  */
-process.on('SIGINT', function () {
-   console.log('Got SIGINT ! Stopping activity poller after this request...please wait...');
-   activityPoller.stop();
-});
+process.on('SIGINT', activityPoller.stopHandler);
+process.on('SIGTERM', activityPoller.stopHandler);

--- a/examples/simple-decider-worker.js
+++ b/examples/simple-decider-worker.js
@@ -50,11 +50,8 @@ myDecider.start();
  * It is not recommanded to stop the poller in the middle of a long-polling request,
  * because SWF might schedule an DecisionTask to this poller anyway, which will obviously timeout.
  *
- * The .stop() method will wait for the end of the current polling request, 
+ * The .stopHandler() method will wait for the end of the current polling request,
  * eventually wait for a last decision execution, then stop properly :
  */
-process.on('SIGINT', function () {
-   console.log('Got SIGINT ! Stopping decider poller after this request...please wait...');
-   myDecider.stop();
-});
-
+process.on('SIGINT', myDecider.stopHandler);
+process.on('SIGTERM', myDecider.stopHandler);

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -51,6 +51,21 @@ var Poller = exports.Poller = function(config, swfClient) {
     * @abstract
     */
    this.pollMethod = "abstract";
+
+   /**
+    * Handler that can be attached to termination signals<br />
+    * On the first invocation calls stop() and logs an message, otherwise does nothing.<br />
+    * Use it like this:
+    *
+    *    process.on('SIGINT', poller.stopHandler);
+    *    process.on('SIGTERM', poller.stopHandler);
+    */
+   this.stopHandler = function (x, y, z) {
+      if (!self.stop_poller) {
+        self.logger.info('Stopping the poller after this request...');
+        self.stop();
+      }
+   };
 };
 
 util.inherits(Poller, events.EventEmitter);
@@ -95,7 +110,7 @@ Poller.prototype.stop = function () {
 Poller.prototype.poll = function () {
 
    if (this.stop_poller || this.pause_poller) {
-      //console.log(this.config.identity + ": stop_poller, quitting properly...");
+      this.logger.info('Poller stopped, shutting down...');
       return;
    }
 

--- a/test/test_ActivityPoller.js
+++ b/test/test_ActivityPoller.js
@@ -17,6 +17,7 @@ var swfClientMock = {
         }, 10);
     }
 };
+var nullLogger = { info: function() {} };
 
 describe('ActivityPoller', function(){
 
@@ -41,7 +42,8 @@ describe('ActivityPoller', function(){
         domain: 'test-domain',
         taskList: {
           name: 'test-taskList'
-        }
+        },
+        logger: nullLogger
       }, swfClientMock);
 
 


### PR DESCRIPTION
In this commit:

* Adding convenience `stopHandler()` to reduce duplication when registering handlers for both SIGINT and SIGTERM
* Updated examples to use stopHandler
* Added unit tests

The motivation is easier integration with supervisor. If I start my decider like this

```shell
supervisor -- decider.js
```

using [supervisor](https://github.com/petruisfan/node-supervisor), and only register a handler for `SIGINT`, the process will get terminated immediately instead of waiting for the last long poll to complete.

Registering a handler for both `SIGINT` and `SIGTERM` fixes the issue, and seems like a good idea anyhow.

This PR just makes it a bit easier to register the handler twice and ensure that `stop()` is only called once. Although it doesn't matter at the moment if stop is called more than once, implementation details may change in the future. It also logs `Stopping the poller after this request...` only once.