### PR TITLE
Extra check for poller resume.

### DIFF
--- a/lib/poller.js
+++ b/lib/poller.js
@@ -31,10 +31,14 @@ var Poller = exports.Poller = function(config, swfClient) {
     queueFunc(callback);
    }, this.taskLimitation);
    this.taskQueue.drain = function(){
-    self.resume();
+    if (this.pause_poller) {
+      self.resume();
+    }
    };
    this.taskQueue.saturated = function(){
-    self.pause();
+    if (!this.pause_poller) {
+      self.pause();
+    }
    };
 
    /**
@@ -59,8 +63,11 @@ util.inherits(Poller, events.EventEmitter);
  * Resume the poller
  */
 Poller.prototype.resume = function() {
-   this.pause_poller = false;
-   this.poll();
+   // start new poll only if the poller was paused
+   if (this.pause_poller) {
+     this.pause_poller = false;
+     this.poll();
+   }
 };
 
 /**


### PR DESCRIPTION
Occasionally the queue can be drained, and extra resume() will be called. 
These couple of lines will prevent the new poll method to start if the previous is still running (not paused).
The bug caused the number of polling methods to increase indefinitely. I had around 180 calls to SWF per minute on my running instance.