### PR TITLE
Fixed error 'SimpleWorkflow() is not a constructor.

### DIFF
--- a/lib/swf.js
+++ b/lib/swf.js
@@ -4,7 +4,7 @@ var AWS = require('aws-sdk');
  * Create a AWS SWF client using the aws-sdk.
  */
 exports.createClient = function () {
-    var swfClient = new AWS.SimpleWorkflow();
+    var swfClient = new AWS.SWF();
     return swfClient;
 };
 


### PR DESCRIPTION
The error started to occur recently. Probably the new version of the AWS-SDK removed/renamed SimpleWorkflow to SWF completely.