### PR TITLE
Add handler for workflow cancel request

### DIFF
--- a/lib/event-list.js
+++ b/lib/event-list.js
@@ -479,6 +479,21 @@ EventList.prototype = {
     */
    get_history: function () {
       return this._events;
+   },
+    
+   /**
+   * Return true if cancel request has arrived
+   * @returns {boolean}
+   */
+   workflow_cancel_requested : function(){
+       for (i = 0; i < this._events.length; i++) {
+           var evt = this._events[i];
+           if (evt.eventType === "WorkflowExecutionCancelRequested") {
+               return true;
+           }
+       }
+       return false;
+
    }
 
 

--- a/lib/event-list.js
+++ b/lib/event-list.js
@@ -486,6 +486,7 @@ EventList.prototype = {
    * @returns {boolean}
    */
    workflow_cancel_requested : function(){
+       var i; 
        for (i = 0; i < this._events.length; i++) {
            var evt = this._events[i];
            if (evt.eventType === "WorkflowExecutionCancelRequested") {


### PR DESCRIPTION
Add capacity from decider code to know if someone asked for workflow cancellation (ex aws console cancel button)

ex : 

```
function deciderLogic(decisionTask) {

           if (decisionTask.eventList.workflow_cancel_requested()){
                //handle a graceful cancel before sending a terminate workflow message

           }
}
```